### PR TITLE
timestamp uses non RFC3339 format. just pass it through to the user a…

### DIFF
--- a/artifactory/buildinfo/buildinfo.go
+++ b/artifactory/buildinfo/buildinfo.go
@@ -185,12 +185,12 @@ type Vcs struct {
 }
 
 type Status struct {
-	Status        string    `json:"status,omitempty"`
-	Comment       string    `json:"comment,omitempty"`
-	Timestamp     time.Time `json:"timestamp,omitempty"`
-	User          string    `json:"user,omitempty"`
-	CiUser        string    `json:"ciUser,omitempty"`
-	TimestampDate int64     `json:"timestampDate,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Comment       string `json:"comment,omitempty"`
+	Timestamp     string `json:"timestamp,omitempty"`
+	User          string `json:"user,omitempty"`
+	CiUser        string `json:"ciUser,omitempty"`
+	TimestampDate int64  `json:"timestampDate,omitempty"`
 }
 
 type Partials []*Partial


### PR DESCRIPTION
…s a string.

- [ ] All [tests](https://github.com/jfrog/jfrog-client-go#tests) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
- [ ] I used gofmt for formatting the code before submitting the pull request.
-----
